### PR TITLE
ignore bot users

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,16 @@
 # slackers
 
-compare SSO slack users to an LDAP source
+Find SSO slack users that should be deactivated according to an LDAP source
 
 ## build
 
 ```
-docker-compose run make
+docker-compose run make <darwin/linux/windows>
 ```
 
-# configure it
+## configure
 
-* copy config.example to config.ini
+* copy **config.example** to config.ini
 * edit the values in config.ini for your ldap/AD server
 * set a couple of secrets as environment variables
 
@@ -29,6 +29,11 @@ docker-compose run make
 
   Available commands are:
       disabled    scan for all disabled AD users that are live slackers
+
+                  -purge ...let the app to kill the targeted users from Slack
+                  -o json ...outputs result in JSON that is machine friendly
+                  -o stdout ...outputs result in stdout (default)
+
       report      list all live slackers
   ```
 

--- a/disabled.go
+++ b/disabled.go
@@ -75,11 +75,10 @@ func (c *DisabledUsersCommand) Run(args []string) int {
 
 	for _, u := range lusers {
 		for _, v := range susers {
-			if v.Name == "slackbot" {
+			if v.IsBot == true {
 				continue
 			}
 			if strings.EqualFold(u.Email, v.Profile.Email) {
-				// if u.Email == v.Profile.Email {
 				fmt.Printf("warning: found a live slacker that should be dead: %s,%s,%s\n", v.Name, v.Profile.Email, v.ID)
 
 				if c.Purge {

--- a/disabled.go
+++ b/disabled.go
@@ -1,18 +1,20 @@
 package main
 
 import (
+	"encoding/json"
 	"flag"
 	"fmt"
 	"os"
 	"strings"
 
 	"github.com/mitchellh/cli"
-	//	"sync"
+	"github.com/nlopes/slack"
 )
 
 type DisabledUsersCommand struct {
-	Purge bool
-	Ui    cli.Ui
+	Purge        bool
+	OutputFormat string
+	Ui           cli.Ui
 }
 
 func disabledUsersCmdFactory() (cli.Command, error) {
@@ -24,8 +26,9 @@ func disabledUsersCmdFactory() (cli.Command, error) {
 	}
 
 	return &DisabledUsersCommand{
-		Purge: false,
-		Ui:    ui,
+		Purge:        false,
+		OutputFormat: "stdout",
+		Ui:           ui,
 	}, nil
 }
 
@@ -33,6 +36,7 @@ func (c *DisabledUsersCommand) Run(args []string) int {
 
 	cmdFlags := flag.NewFlagSet("disabled", flag.ContinueOnError)
 	cmdFlags.BoolVar(&c.Purge, "purge", false, "deactivate live slackers that are disabled in AD")
+	cmdFlags.StringVar(&c.OutputFormat, "o", "stdout", "desired output format")
 	cmdFlags.Usage = func() { c.Ui.Output(c.Help()); os.Exit(1) }
 	if err := cmdFlags.Parse(args); err != nil {
 		return 1
@@ -56,9 +60,6 @@ func (c *DisabledUsersCommand) Run(args []string) int {
 		fmt.Printf("error scanning for ldap users: %s\n", err)
 		os.Exit(1)
 	}
-	// for _, u := range lusers {
-	// 	fmt.Printf("ldap: %s,%s\n", u.CN, u.Email)
-	// }
 
 	srunner, err := NewSlackRunner()
 	if err != nil {
@@ -72,6 +73,8 @@ func (c *DisabledUsersCommand) Run(args []string) int {
 		fmt.Printf("error scanning for slack users: %s\n", err)
 		os.Exit(1)
 	}
+	// stack for targeted users
+	var tusers []slack.User
 
 	for _, u := range lusers {
 		for _, v := range susers {
@@ -79,8 +82,12 @@ func (c *DisabledUsersCommand) Run(args []string) int {
 				continue
 			}
 			if strings.EqualFold(u.Email, v.Profile.Email) {
-				fmt.Printf("warning: found a live slacker that should be dead: %s,%s,%s\n", v.Name, v.Profile.Email, v.ID)
-
+				if c.OutputFormat == "stdout" {
+					fmt.Printf("warning: found a live slacker that should be dead: %s,%s,%s\n", v.Name, v.Profile.Email, v.ID)
+				}
+				if c.OutputFormat == "json" {
+					tusers = append(tusers, v)
+				}
 				if c.Purge {
 					resp, err := srunner.DeleteUser(&v)
 					if err != nil {
@@ -91,7 +98,10 @@ func (c *DisabledUsersCommand) Run(args []string) int {
 			}
 		}
 	}
-
+	if c.OutputFormat == "json" {
+		js, _ := json.Marshal(tusers)
+		fmt.Println(string(js))
+	}
 	return 0
 }
 
@@ -101,7 +111,7 @@ func (c *DisabledUsersCommand) Help() string {
 List all disabled AD users that are live slackers
 
 Options:
-            -purge          deactivate live slackers that are deactive in AD
+            -purge          deactivate live slackers that are deactived in AD
 
 
 	`

--- a/disabled.go
+++ b/disabled.go
@@ -78,6 +78,9 @@ func (c *DisabledUsersCommand) Run(args []string) int {
 
 	for _, u := range lusers {
 		for _, v := range susers {
+			if v.Name == "slackbot" {
+				continue
+			}
 			if v.IsBot == true {
 				continue
 			}

--- a/main.go
+++ b/main.go
@@ -9,7 +9,7 @@ import (
 
 func main() {
 
-	c := cli.NewCLI("slackers", "0.1.0")
+	c := cli.NewCLI("slackers", "0.1.1")
 	c.Args = os.Args[1:]
 
 	c.Commands = map[string]cli.CommandFactory{


### PR DESCRIPTION
This PR will: 
- leveraging slack lib's build-in feature help to ignore the current bot users on Slack. Somethings have changed in Slack that sometimes a bot user can have other name than `slackbot`.
- allow Slackers to output in JSON with `-o json`.
 